### PR TITLE
Add Hub-IO configuration

### DIFF
--- a/.github/hub-io.yml
+++ b/.github/hub-io.yml
@@ -1,0 +1,12 @@
+version: 1
+layout:
+  columns: 6
+  avatarSize: 72
+  cardRadius: 32
+contributors:
+  maxCount: 24
+  includeBots: false
+theme:
+  background: "#08111f"
+  stroke: "#17304f"
+  title: Contributors


### PR DESCRIPTION
This PR adds the single Hub-IO config file used by the Vercel app to render contributor assets and keep the onboarding flow lightweight.