### PR TITLE
docs(readme): 美化说明并补充 Go Agent 库调研

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,55 @@
 # mini-claude-code
 
-> 本仓库是一个面向 Agent 开发初学者的教学项目仓库，早期使用 TypeScript + AI SDK 实现，现在切换为 Golang + Openai ADK + BubbleTea 实现。
+> 一个面向 Agent 开发初学者的教学仓库：从 TypeScript + AI SDK 的原型，到 Go + Bubble Tea 的可运行终端 Code Agent。
 >
 > Bilibili 视频教学：[Agent 到底是什么？从原理、开发到落地的一次真实分享；2026 年 3 月 14 日 - 华中科技大学](https://www.bilibili.com/video/BV1eiwRzPE4n/)
 >
 > Issue 风格教案：[完整教案 Issue #2](https://github.com/minorcell/mini-claude-code/issues/2)
 
-`mini-opencode` 是一个 Code Agent 项目。它基于 Go + Bubble Tea，提供终端内的代码读取、工具调用、shell 执行与 todo 管理能力，并将过程保留在同一个 TUI 会话里。
+`mini-opencode` 是当前主线实现。它在终端（TUI）里提供文件操作、工具调用、Shell 执行、Todo 管理和多模型接入能力，方便边学边改边验证。
 
-## 仓库结构
+## 1. 这是什么项目
+
+这是一个“教学 + 实战”混合仓库，目标是帮助你理解并构建一个最小可用的 Code Agent。
+
+- 教学线：`examples/` 里保留从手写 agent loop 到 SDK 化实现的过程
+- 工程线：`cmd/mini-opencode` + `internal/*` 提供 Go 版可运行实现
+- 产品线：通过 Bubble Tea TUI 把会话、上下文、工具执行放在一个交互界面
+
+## 2. 仓库结构
 
 - `cmd/mini-opencode`：程序入口
 - `internal/config`：配置加载与默认值
-- `internal/core`：agent loop、session、逐步事件广播
+- `internal/core`：agent loop、session、step 事件广播
 - `internal/provider`：统一模型接口，适配 `openai` / `openai-compatible` / `anthropic` / `gemini`
 - `internal/tools`：工具注册中心、工作区约束、安全拦截器、内置工具
 - `internal/tui`：Bubble Tea 交互界面
 - `docs/`：主线项目设计文档
 - `examples/`：教学示例（`agent-loop`、`mini-claude-code`）
 
-## 功能概览
+## 3. 与 TS AI SDK 示例的关系
+
+`examples/mini-claude-code` 是上一阶段教学实现（TypeScript + Vercel AI SDK），重点展示：
+
+- SDK 原生 tool calling
+- `generateText + maxSteps` 的多步推理
+- 上下文压缩和工具输出截断
+
+Go 主线 `mini-opencode` 在这个基础上继续演进：
+
+- 从脚本式 CLI 过渡到 Bubble Tea TUI
+- 从示例级代码过渡到分层架构（config/core/provider/tools/tui）
+- 保留教学可读性的同时提高工程可维护性
+
+## 4. 功能概览
 
 界面由三个区域组成：
 
-- `Conversation`：完整展示 user / assistant / tool 的叙事和结果
+- `Conversation`：展示 user / assistant / tool 叙事和结果
 - `Context`：展示会话状态、token 统计、step 进度、todo 侧栏
 - `Composer`：输入区，支持排队下一条消息和 `@文件` 候选补全
 
-## 快速开始
+## 5. 快速开始
 
 ```bash
 go run ./cmd/mini-opencode
@@ -41,13 +63,13 @@ go run ./cmd/mini-opencode
 export OPENAI_API_KEY="your_api_key"
 ```
 
-跑测试：
+运行测试：
 
 ```bash
 go test ./...
 ```
 
-## 配置
+## 6. 配置
 
 默认配置文件路径：
 
@@ -103,7 +125,7 @@ provider:
 - `workspace`、`provider.url`、`provider.model_id` 支持环境变量展开
 - `provider.type` 会自动规范化别名，例如 `compatible` 会折叠成 `openai-compatible`
 
-## 内置工具
+## 7. 内置工具
 
 | 工具 | 说明 |
 | --- | --- |
@@ -117,7 +139,33 @@ provider:
 | `todo` | 维护任务 todo 列表，右侧 `Context` 会渲染状态 |
 | `webfetch` | 抓取 HTTP(S) 页面或接口，HTML 会被剥离为纯文本 |
 
-## 交互方式
+## 8. Go Agent 库调研（对照 TS AI SDK）
+
+调研时间：2026-04-13（UTC）
+
+TS 侧常见参考：
+
+- `vercel/ai`（AI SDK）
+- `openai/openai-agents-js`（多 Agent 与语音）
+- `mastra-ai/mastra`（TS Agent 应用框架）
+
+Go 侧可选库：
+
+| 库 | 定位 | 对 TS AI SDK 的参考关系 | 适用场景 |
+| --- | --- | --- | --- |
+| `google/adk-go` | Google ADK 的 Go 实现，完整 agent toolkit | 更接近“全栈 agent 框架” | 想快速搭建复杂多 Agent、评估与部署流程 |
+| `tmc/langchaingo` | LangChain 的 Go 生态实现 | 类似 TS 里用链路/组件编排替代手写 loop | 需要丰富组件生态与抽象层 |
+| `cloudwego/eino` | CloudWeGo 的 LLM/Agent 框架 | 更偏工程化编排与生产实践 | 企业内 Go 服务化集成 |
+| `mark3labs/mcp-go` | MCP 协议 Go 实现（client/server） | 对应 TS 生态里的 MCP 接入能力 | 需要与 MCP 工具生态对接 |
+| `openai/openai-go` + `anthropics/anthropic-sdk-go` | 官方模型 SDK | 对应 TS SDK 的 provider 层 | 自建轻量 Agent Loop，保留高可控性 |
+
+### 选型建议（结合本仓库）
+
+- 如果保持“教学 + 高可控”路线：继续当前 `core + tools + provider + tui` 架构，优先增强可观测性和工具安全。
+- 如果要补齐生态互联：优先引入 `mcp-go`，把外部工具能力标准化接入。
+- 如果要快速扩展复杂工作流：可评估 `adk-go` 或 `eino` 做实验分支，对比学习成本与运行开销。
+
+## 9. 交互方式
 
 - `Enter`：发送消息；如果 turn 还在运行，会排队 1 条后续消息
 - `Ctrl+J`：在 Composer 里插入换行
@@ -129,7 +177,7 @@ provider:
 - 鼠标滚轮：滚动 `Conversation` 记录
 - `Ctrl+C`：退出程序
 
-## 已知边界
+## 10. 已知边界
 
 - `glob` 走的是 Go `filepath.Glob` 语义，不支持把 `**` 当成递归 doublestar
 - 右侧 `Context` 用于展示 token、step、todo 等状态信息；详细工具输出显示在 `Conversation`
@@ -137,4 +185,5 @@ provider:
 - `read` 和 `webfetch` 的内容上限都是 64KB
 
 ## Contributors
+
 ![](https://hub-io-mcells-projects.vercel.app/r/minorcell/mini-claude-code)


### PR DESCRIPTION
Requested by @minorcell

本 PR 完成 Issue #12 中的文档侧需求：

## Summary
- 重新组织 README 结构，补充“这是什么项目”与主线架构说明
- 明确 Go 主线与 `examples/mini-claude-code`（TS AI SDK 示例）的关系
- 新增 Go Agent 库调研章节，并对照 TS 生态给出选型建议

## Notes
- 运行了 `go test ./...`，当前环境因 `gcc: unrecognized command-line option '-m64'` 导致构建失败（与本次 README 文档修改无直接关系）