### PR TITLE
fix(tools): 修复 read_tool limit 性能问题及 grep_tool 代码规范

### DIFF
--- a/internal/tools/grep_tool.go
+++ b/internal/tools/grep_tool.go
@@ -103,10 +103,10 @@ func (t *GrepTool) Execute(_ context.Context, invocation Invocation) (Result, er
 		maxResults = 50
 	}
 
-	return t.grep(target, args.Pattern, args.Glob, args.Regex, args.IgnoreCase, maxResults, args.Context)
+	return t.grep(target, args.Pattern, args.Glob, args.Regex, args.IgnoreCase, maxResults)
 }
 
-func (t *GrepTool) grep(dir, pattern, fileGlob string, isRegex, ignoreCase bool, maxResults, contextLines int) (Result, error) {
+func (t *GrepTool) grep(dir, pattern, fileGlob string, isRegex, ignoreCase bool, maxResults int) (Result, error) {
 	var re *regexp.Regexp
 	var err error
 
@@ -143,7 +143,7 @@ func (t *GrepTool) grep(dir, pattern, fileGlob string, isRegex, ignoreCase bool,
 			}
 		}
 
-		matches := t.searchFile(path, pattern, re, ignoreCase, dir, contextLines)
+		matches := t.searchFile(path, pattern, re, ignoreCase, dir)
 		for _, m := range matches {
 			if matchCount >= maxResults {
 				break
@@ -174,7 +174,7 @@ func (t *GrepTool) grep(dir, pattern, fileGlob string, isRegex, ignoreCase bool,
 	}, nil
 }
 
-func (t *GrepTool) searchFile(filePath, pattern string, re *regexp.Regexp, ignoreCase bool, baseDir string, contextLines int) []string {
+func (t *GrepTool) searchFile(filePath, pattern string, re *regexp.Regexp, ignoreCase bool, baseDir string) []string {
 	file, err := os.Open(filePath)
 	if err != nil {
 		return nil
@@ -205,6 +205,10 @@ func (t *GrepTool) searchFile(filePath, pattern string, re *regexp.Regexp, ignor
 			}
 			lines = append(lines, fmt.Sprintf("%s:%d: %s", relPath, lineNum, line))
 		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil
 	}
 
 	return lines

--- a/internal/tools/read_tool.go
+++ b/internal/tools/read_tool.go
@@ -125,7 +125,7 @@ func (t *ReadTool) readLines(target string, offset, limit, maxBytes int) (Result
 		}
 
 		if limit > 0 && len(lines) >= limit {
-			continue
+			break
 		}
 
 		lines = append(lines, fmt.Sprintf("%6d\t%s", totalLines, line))


### PR DESCRIPTION
Requested by @minorcell

关闭 #16

## 问题排查

| # | 严重性 | 文件 | 行 | 问题描述 |
|---|--------|------|----|----------|
| 1 | **高** | `read_tool.go` | 127 | `limit` 达到后使用 `continue` 而非 `break`，导致仍扫描整个文件（性能问题） |
| 2 | **中** | `grep_tool.go` | 208 | 扫描循环结束后未调用 `scanner.Err()`，可能静默忽略 I/O 错误 |
| 3 | **低** | `grep_tool.go` | 177 | `contextLines` 参数在函数内从未使用（代码冗余） |

## 修复内容

- `read_tool.go`: `continue` → `break`，读取到 limit 行后立即停止扫描
- `grep_tool.go`: 在 `searchFile` 扫描循环结束后添加 `scanner.Err()` 检查
- `grep_tool.go`: 移除 `grep`、`searchFile` 中未使用的 `contextLines` 参数及其传递