### PR TITLE
fix(tools): 修复 read/grep 边界错误并补测试

### DIFF
--- a/internal/tools/grep_tool.go
+++ b/internal/tools/grep_tool.go
@@ -143,7 +143,10 @@ func (t *GrepTool) grep(dir, pattern, fileGlob string, isRegex, ignoreCase bool,
 			}
 		}
 
-		matches := t.searchFile(path, pattern, re, ignoreCase, dir, contextLines)
+		matches, searchErr := t.searchFile(path, pattern, re, ignoreCase, dir, contextLines)
+		if searchErr != nil {
+			return searchErr
+		}
 		for _, m := range matches {
 			if matchCount >= maxResults {
 				break
@@ -174,38 +177,73 @@ func (t *GrepTool) grep(dir, pattern, fileGlob string, isRegex, ignoreCase bool,
 	}, nil
 }
 
-func (t *GrepTool) searchFile(filePath, pattern string, re *regexp.Regexp, ignoreCase bool, baseDir string, contextLines int) []string {
+func (t *GrepTool) searchFile(filePath, pattern string, re *regexp.Regexp, ignoreCase bool, baseDir string, contextLines int) ([]string, error) {
 	file, err := os.Open(filePath)
 	if err != nil {
-		return nil
+		return nil, nil
 	}
 	defer file.Close()
 
-	var lines []string
+	var fileLines []string
 	scanner := bufio.NewScanner(file)
-	lineNum := 0
 
 	for scanner.Scan() {
-		lineNum++
-		line := scanner.Text()
+		fileLines = append(fileLines, scanner.Text())
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan file %q: %w", filePath, err)
+	}
 
-		var matched bool
-		if re != nil {
-			matched = re.MatchString(line)
-		} else if ignoreCase {
-			matched = strings.Contains(strings.ToLower(line), strings.ToLower(pattern))
-		} else {
-			matched = strings.Contains(line, pattern)
+	relPath, err := filepath.Rel(baseDir, filePath)
+	if err != nil {
+		relPath = filePath
+	}
+
+	var lines []string
+	if contextLines <= 0 {
+		for i, line := range fileLines {
+			if lineMatched(line, pattern, re, ignoreCase) {
+				lines = append(lines, fmt.Sprintf("%s:%d: %s", relPath, i+1, line))
+			}
+		}
+		return lines, nil
+	}
+
+	selectedLineNumbers := make(map[int]struct{})
+	for i, line := range fileLines {
+		if !lineMatched(line, pattern, re, ignoreCase) {
+			continue
 		}
 
-		if matched {
-			relPath, err := filepath.Rel(baseDir, filePath)
-			if err != nil {
-				relPath = filePath
-			}
-			lines = append(lines, fmt.Sprintf("%s:%d: %s", relPath, lineNum, line))
+		start := i - contextLines
+		if start < 0 {
+			start = 0
+		}
+		end := i + contextLines
+		if end >= len(fileLines) {
+			end = len(fileLines) - 1
+		}
+		for j := start; j <= end; j++ {
+			selectedLineNumbers[j] = struct{}{}
 		}
 	}
 
-	return lines
+	for i, line := range fileLines {
+		if _, ok := selectedLineNumbers[i]; !ok {
+			continue
+		}
+		lines = append(lines, fmt.Sprintf("%s:%d: %s", relPath, i+1, line))
+	}
+
+	return lines, nil
+}
+
+func lineMatched(line, pattern string, re *regexp.Regexp, ignoreCase bool) bool {
+	if re != nil {
+		return re.MatchString(line)
+	}
+	if ignoreCase {
+		return strings.Contains(strings.ToLower(line), strings.ToLower(pattern))
+	}
+	return strings.Contains(line, pattern)
 }

--- a/internal/tools/read_grep_tool_test.go
+++ b/internal/tools/read_grep_tool_test.go
@@ -1,0 +1,88 @@
+package tools
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestReadToolLimitStopsScanningAtLimit(t *testing.T) {
+	root := t.TempDir()
+	path := writeTestFile(t, root, "sample.txt", "a\n"+strings.Repeat("b", 20)+"\n"+strings.Repeat("c", 20)+"\n")
+
+	tool := NewReadTool(root)
+	result, err := tool.readLines(path, 1, 1, 10)
+	if err != nil {
+		t.Fatalf("readLines() error = %v", err)
+	}
+
+	if got := metadataBool(result.Metadata["truncated"]); got {
+		t.Fatalf("truncated = true, want false")
+	}
+	if got := metadataInt(result.Metadata["read_lines"]); got != 1 {
+		t.Fatalf("read_lines = %d, want 1", got)
+	}
+}
+
+func TestGrepToolContextIncludesAdjacentLines(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, root, "file.txt", "line-1\nmatch\nline-3\n")
+
+	tool := NewGrepTool(root)
+	result, err := tool.Execute(context.Background(), Invocation{
+		Arguments: []byte(`{"path":".","pattern":"match","context":1}`),
+	})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	output := result.Output
+	if !strings.Contains(output, "file.txt:1: line-1") {
+		t.Fatalf("expected output to include previous context line, got %q", output)
+	}
+	if !strings.Contains(output, "file.txt:2: match") {
+		t.Fatalf("expected output to include matched line, got %q", output)
+	}
+	if !strings.Contains(output, "file.txt:3: line-3") {
+		t.Fatalf("expected output to include next context line, got %q", output)
+	}
+}
+
+func TestGrepToolReturnsScanError(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, root, "long.txt", strings.Repeat("x", 70*1024)+"\n")
+
+	tool := NewGrepTool(root)
+	_, err := tool.Execute(context.Background(), Invocation{
+		Arguments: []byte(`{"path":".","pattern":"x"}`),
+	})
+	if err == nil {
+		t.Fatal("expected Execute() to return scanner error for very long line")
+	}
+	if !strings.Contains(err.Error(), "token too long") {
+		t.Fatalf("unexpected error %q", err)
+	}
+}
+
+func writeTestFile(t *testing.T, root, relPath, content string) string {
+	t.Helper()
+
+	absPath, err := SafeJoin(root, relPath)
+	if err != nil {
+		t.Fatalf("SafeJoin() error = %v", err)
+	}
+	if err := os.WriteFile(absPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write file %q: %v", absPath, err)
+	}
+	return absPath
+}
+
+func metadataBool(value any) bool {
+	switch actual := value.(type) {
+	case bool:
+		return actual
+	default:
+		return false
+	}
+}

--- a/internal/tools/read_tool.go
+++ b/internal/tools/read_tool.go
@@ -111,21 +111,21 @@ func (t *ReadTool) readLines(target string, offset, limit, maxBytes int) (Result
 	bytesRead := 0
 
 	for scanner.Scan() {
-		totalLines++
-		line := scanner.Text()
-		bytesRead += len(line) + 1
-
-		if bytesRead > maxBytes {
-			truncated = true
+		if limit > 0 && len(lines) >= limit {
 			break
 		}
+
+		totalLines++
+		line := scanner.Text()
 
 		if offset > 0 && totalLines < offset {
 			continue
 		}
 
-		if limit > 0 && len(lines) >= limit {
-			continue
+		bytesRead += len(line) + 1
+		if bytesRead > maxBytes {
+			truncated = true
+			break
 		}
 
 		lines = append(lines, fmt.Sprintf("%6d\t%s", totalLines, line))


### PR DESCRIPTION
Requested by @minorcell

修复 issue #16 中继续排查得到的工具层问题，包含错误处理和代码规范一致性。

## Summary
- 修复 `read_tool`：达到 `limit` 后立即停止扫描，避免不必要读取与误判截断
- 修复 `grep_tool`：补充 `scanner.Err()` 处理并向上返回错误
- 修复 `grep_tool`：让 `context` 参数真正生效，返回命中行上下文
- 新增 `internal/tools/read_grep_tool_test.go` 覆盖上述场景

## Validation
- `CGO_ENABLED=0 go test ./internal/tools ./internal/core ./internal/config ./internal/tui`
- `CGO_ENABLED=0 go vet ./internal/tools ./internal/core ./internal/config ./internal/tui`