### PR TITLE
refactor: 移除项目中所有代码注释

### DIFF
--- a/cmd/mini-opencode/main.go
+++ b/cmd/mini-opencode/main.go
@@ -1,4 +1,3 @@
-// Package main 提供 mini-opencode 的程序入口。
 package main
 
 import (
@@ -20,7 +19,6 @@ func main() {
 	}
 }
 
-// run 负责加载配置、构建依赖并启动 TUI。
 func run() error {
 	configPath, err := config.DefaultPath()
 	if err != nil {
@@ -69,7 +67,6 @@ func run() error {
 	})
 }
 
-// buildClient 根据 provider.type 构建对应的协议客户端。
 func buildClient(cfg config.Config) (provider.Client, string, error) {
 	providerType := cfg.EffectiveProviderType()
 	modelName := cfg.EffectiveModel()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,4 +1,3 @@
-// Package config 负责加载、规范化并提供运行配置。
 package config
 
 import (
@@ -20,12 +19,10 @@ const (
 //go:embed prompt.md
 var promptContent string
 
-// SystemPrompt 返回内置的系统提示词。
 func SystemPrompt() string {
 	return promptContent
 }
 
-// Config 描述 mini-opencode 的运行配置。
 type Config struct {
 	Provider    ProviderConfig `yaml:"provider"`
 	MaxTokens   int            `yaml:"max_tokens"`
@@ -34,9 +31,6 @@ type Config struct {
 	Workspace   string         `yaml:"workspace"`
 }
 
-// ProviderConfig 描述单个模型接入点。
-//
-// Name 用于展示接入名称，Type 用于选择底层 API 协议适配器。
 type ProviderConfig struct {
 	Name      string `yaml:"name"`
 	Type      string `yaml:"type"`
@@ -45,7 +39,6 @@ type ProviderConfig struct {
 	ModelID   string `yaml:"model_id"`
 }
 
-// Default 返回可直接启动程序的默认配置。
 func Default() Config {
 	return Config{
 		Provider: ProviderConfig{
@@ -61,7 +54,6 @@ func Default() Config {
 	}
 }
 
-// DefaultPath 返回默认配置文件路径。
 func DefaultPath() (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -71,7 +63,6 @@ func DefaultPath() (string, error) {
 	return filepath.Join(home, ".mini-opencode", "config.yaml"), nil
 }
 
-// Load 从指定路径加载配置；当文件不存在时会回退到默认配置。
 func Load(path string) (Config, error) {
 	if strings.TrimSpace(path) == "" {
 		var err error
@@ -104,17 +95,14 @@ func Load(path string) (Config, error) {
 	return cfg, nil
 }
 
-// EffectiveModel 返回当前生效的模型 ID。
 func (c Config) EffectiveModel() string {
 	return strings.TrimSpace(c.Provider.ModelID)
 }
 
-// EffectiveProviderType 返回规范化后的 provider 类型。
 func (c Config) EffectiveProviderType() string {
 	return normalizeProviderType(c.Provider.Type)
 }
 
-// ProviderAPIKey 根据 env_api_key 指向的环境变量读取真实 API Key。
 func (c Config) ProviderAPIKey() string {
 	envName := strings.TrimSpace(c.Provider.EnvAPIKey)
 	if envName == "" {
@@ -123,7 +111,6 @@ func (c Config) ProviderAPIKey() string {
 	return strings.TrimSpace(os.Getenv(envName))
 }
 
-// EffectiveWorkspace 返回当前生效的工作区绝对路径。
 func (c Config) EffectiveWorkspace(cwd string) (string, error) {
 	workspace := strings.TrimSpace(c.Workspace)
 	if workspace == "" {
@@ -142,7 +129,6 @@ func (c Config) EffectiveWorkspace(cwd string) (string, error) {
 	return abs, nil
 }
 
-// initConfigFile 在配置文件不存在时创建目录并写入默认配置。
 func initConfigFile(path string, cfg *Config) error {
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
@@ -161,7 +147,6 @@ func initConfigFile(path string, cfg *Config) error {
 	return nil
 }
 
-// applyEnv 预留给环境变量合并逻辑扩展，目前默认配置已足够覆盖启动路径。
 func (c *Config) applyEnv() {}
 
 func (c *Config) normalize() {
@@ -211,7 +196,6 @@ func expandHome(path string) (string, error) {
 	return path, nil
 }
 
-// normalizeProviderType 将用户输入的 provider.type 统一折叠为内部标准值。
 func normalizeProviderType(value string) string {
 	normalized := strings.ToLower(strings.TrimSpace(value))
 	switch normalized {
@@ -228,7 +212,6 @@ func normalizeProviderType(value string) string {
 	}
 }
 
-// defaultProviderURL 返回不同 provider 类型的默认 API 地址。
 func defaultProviderURL(providerType string) string {
 	switch normalizeProviderType(providerType) {
 	case "anthropic":
@@ -242,7 +225,6 @@ func defaultProviderURL(providerType string) string {
 	}
 }
 
-// defaultEnvAPIKey 返回不同 provider 类型推荐使用的默认环境变量名。
 func defaultEnvAPIKey(providerType string) string {
 	switch normalizeProviderType(providerType) {
 	case "anthropic":
@@ -256,7 +238,6 @@ func defaultEnvAPIKey(providerType string) string {
 	}
 }
 
-// defaultModelID 返回不同 provider 类型的默认模型 ID。
 func defaultModelID(providerType string) string {
 	switch normalizeProviderType(providerType) {
 	case "anthropic":

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 )
 
-// TestLoadUsesProviderEnvAPIKey 验证 env_api_key 能正确解析真实 API Key。
 func TestLoadUsesProviderEnvAPIKey(t *testing.T) {
 	t.Setenv("MY_GATEWAY_KEY", "secret-value")
 
@@ -21,7 +20,6 @@ func TestLoadUsesProviderEnvAPIKey(t *testing.T) {
 	}
 }
 
-// TestNormalizeProviderTypeAliases 验证 provider.type 的别名会被统一折叠。
 func TestNormalizeProviderTypeAliases(t *testing.T) {
 	cfg := Default()
 	cfg.Provider.Type = "openai_compatible"
@@ -32,7 +30,6 @@ func TestNormalizeProviderTypeAliases(t *testing.T) {
 	}
 }
 
-// TestEffectiveWorkspaceExpandsHome 验证工作区路径支持波浪号展开。
 func TestEffectiveWorkspaceExpandsHome(t *testing.T) {
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -53,7 +50,6 @@ func TestEffectiveWorkspaceExpandsHome(t *testing.T) {
 	}
 }
 
-// TestLoadProviderStructFromYAML 验证新的 provider 结构可以从 YAML 正常加载。
 func TestLoadProviderStructFromYAML(t *testing.T) {
 	configPath := filepath.Join(t.TempDir(), "config.yaml")
 	data := []byte(`
@@ -94,7 +90,6 @@ provider:
 	}
 }
 
-// TestNormalizeMaxStepsFallsBackToDefault 验证非法 max_steps 会回退到默认值。
 func TestNormalizeMaxStepsFallsBackToDefault(t *testing.T) {
 	cfg := Default()
 	cfg.MaxSteps = 0

--- a/internal/core/agent.go
+++ b/internal/core/agent.go
@@ -1,4 +1,3 @@
-// Package core 实现会话管理与 agent 执行闭环。
 package core
 
 import (
@@ -12,7 +11,6 @@ import (
 	"github.com/minorcell/mini-claude-code/internal/tools"
 )
 
-// AgentConfig 定义 agent 运行时使用的核心参数。
 type AgentConfig struct {
 	Model       string
 	MaxTokens   int
@@ -21,17 +19,13 @@ type AgentConfig struct {
 	WorkingDir  string
 }
 
-// EventKind 描述一次 turn 中事件的类别。
 type EventKind string
 
 const (
-	// EventAssistant 表示模型生成的助手文本。
 	EventAssistant EventKind = "assistant"
-	// EventTool 表示模型触发并执行了一次工具调用。
-	EventTool EventKind = "tool"
+	EventTool      EventKind = "tool"
 )
 
-// Event 记录一次 turn 中可供上层界面消费的事件。
 type Event struct {
 	Kind       EventKind
 	Content    string
@@ -41,23 +35,16 @@ type Event struct {
 	IsError    bool
 }
 
-// ProgressEventKind 描述一次 turn 的增量执行事件。
 type ProgressEventKind string
 
 const (
-	// ProgressEventStepStarted 表示 agent 进入了新的一步。
-	ProgressEventStepStarted ProgressEventKind = "step_started"
-	// ProgressEventStepCompleted 表示当前步骤已经拿到模型响应和 usage。
-	ProgressEventStepCompleted ProgressEventKind = "step_completed"
-	// ProgressEventAssistantMessage 表示模型在当前步骤产出了可展示文本。
+	ProgressEventStepStarted      ProgressEventKind = "step_started"
+	ProgressEventStepCompleted    ProgressEventKind = "step_completed"
 	ProgressEventAssistantMessage ProgressEventKind = "assistant_message"
-	// ProgressEventToolStarted 表示模型开始执行一次工具调用。
-	ProgressEventToolStarted ProgressEventKind = "tool_started"
-	// ProgressEventToolFinished 表示一次工具调用已经执行完成。
-	ProgressEventToolFinished ProgressEventKind = "tool_finished"
+	ProgressEventToolStarted      ProgressEventKind = "tool_started"
+	ProgressEventToolFinished     ProgressEventKind = "tool_finished"
 )
 
-// ProgressEvent 用于向上层 UI 广播 turn 内部的逐步进展。
 type ProgressEvent struct {
 	Kind       ProgressEventKind
 	Step       int
@@ -72,24 +59,20 @@ type ProgressEvent struct {
 	TotalUsage provider.Usage
 }
 
-// TurnObserver 在 turn 执行期间消费增量事件。
 type TurnObserver func(ProgressEvent)
 
-// TurnResult 表示一次用户输入执行完成后的聚合结果。
 type TurnResult struct {
 	Events []Event
 	Usage  provider.Usage
 	Steps  int
 }
 
-// Agent 负责驱动模型、会话与工具注册表形成完整闭环。
 type Agent struct {
 	client   provider.Client
 	registry *tools.Registry
 	config   AgentConfig
 }
 
-// NewAgent 创建一个新的 agent 实例。
 func NewAgent(client provider.Client, registry *tools.Registry, cfg AgentConfig) *Agent {
 	if cfg.MaxSteps <= 0 {
 		cfg.MaxSteps = 24
@@ -105,12 +88,10 @@ func NewAgent(client provider.Client, registry *tools.Registry, cfg AgentConfig)
 	}
 }
 
-// RunTurn 执行一轮用户输入，并在需要时自动循环工具调用直到得到最终回复。
 func (a *Agent) RunTurn(ctx context.Context, session *Session, userInput string) (TurnResult, error) {
 	return a.runTurn(ctx, session, userInput, nil)
 }
 
-// RunTurnWithObserver 在 RunTurn 基础上额外发出逐步执行事件，适合交互界面实时展示。
 func (a *Agent) RunTurnWithObserver(ctx context.Context, session *Session, userInput string, observer TurnObserver) (TurnResult, error) {
 	return a.runTurn(ctx, session, userInput, observer)
 }
@@ -221,14 +202,12 @@ func (a *Agent) runTurn(ctx context.Context, session *Session, userInput string,
 	return result, fmt.Errorf("agent exceeded max steps (%d)", a.config.MaxSteps)
 }
 
-// cloneMessages 复制消息切片，避免 provider 在调用链中意外修改会话历史。
 func cloneMessages(messages []provider.Message) []provider.Message {
 	cloned := make([]provider.Message, len(messages))
 	copy(cloned, messages)
 	return cloned
 }
 
-// stringifyArguments 将工具参数渲染为更适合展示的格式化 JSON。
 func stringifyArguments(arguments json.RawMessage) string {
 	if len(arguments) == 0 {
 		return "{}"

--- a/internal/core/agent_test.go
+++ b/internal/core/agent_test.go
@@ -45,7 +45,6 @@ func (fakeTool) Execute(_ context.Context, _ tools.Invocation) (tools.Result, er
 	}, nil
 }
 
-// TestRunTurnExecutesToolLoop 验证 agent 能完成一轮工具调用闭环。
 func TestRunTurnExecutesToolLoop(t *testing.T) {
 	registry := tools.NewRegistry()
 	registry.MustRegister(fakeTool{})
@@ -115,7 +114,6 @@ func TestRunTurnExecutesToolLoop(t *testing.T) {
 	}
 }
 
-// TestRunTurnWithObserverEmitsProgress 验证增量观察者会收到逐步执行事件。
 func TestRunTurnWithObserverEmitsProgress(t *testing.T) {
 	registry := tools.NewRegistry()
 	registry.MustRegister(fakeTool{})

--- a/internal/core/session.go
+++ b/internal/core/session.go
@@ -7,14 +7,12 @@ import (
 	"github.com/minorcell/mini-claude-code/internal/provider"
 )
 
-// Session 表示一次对话会话及其消息历史。
 type Session struct {
 	ID        string
 	StartedAt time.Time
 	Messages  []provider.Message
 }
 
-// NewSession 创建一个新会话，并在存在系统提示时自动写入首条 system 消息。
 func NewSession(systemPrompt string) *Session {
 	session := &Session{
 		ID:        fmt.Sprintf("session-%d", time.Now().UnixNano()),
@@ -29,7 +27,6 @@ func NewSession(systemPrompt string) *Session {
 	return session
 }
 
-// Add 向当前会话追加一条消息。
 func (s *Session) Add(message provider.Message) {
 	s.Messages = append(s.Messages, message)
 }

--- a/internal/provider/anthropic.go
+++ b/internal/provider/anthropic.go
@@ -7,21 +7,18 @@ import (
 	"strings"
 )
 
-// AnthropicConfig 描述 Anthropic 协议客户端所需的初始化参数。
 type AnthropicConfig struct {
 	APIKey  string
 	BaseURL string
 	Model   string
 }
 
-// AnthropicClient 实现基于 Anthropic Messages API 的协议适配。
 type AnthropicClient struct {
 	apiKey     string
 	baseURL    string
 	defaultMod string
 }
 
-// NewAnthropicClient 创建一个 Anthropic 协议客户端。
 func NewAnthropicClient(cfg AnthropicConfig) (*AnthropicClient, error) {
 	if strings.TrimSpace(cfg.APIKey) == "" {
 		return nil, fmt.Errorf("anthropic api key is required")
@@ -40,12 +37,10 @@ func NewAnthropicClient(cfg AnthropicConfig) (*AnthropicClient, error) {
 	}, nil
 }
 
-// Name 返回当前客户端的 provider 类型。
 func (c *AnthropicClient) Name() string {
 	return "anthropic"
 }
 
-// Complete 发起一次统一请求，并将 Anthropic 响应转换为公共 Response。
 func (c *AnthropicClient) Complete(ctx context.Context, req Request) (Response, error) {
 	model := strings.TrimSpace(req.Model)
 	if model == "" {

--- a/internal/provider/gemini.go
+++ b/internal/provider/gemini.go
@@ -7,21 +7,18 @@ import (
 	"strings"
 )
 
-// GeminiConfig 描述 Gemini 协议客户端所需的初始化参数。
 type GeminiConfig struct {
 	APIKey  string
 	BaseURL string
 	Model   string
 }
 
-// GeminiClient 实现基于 Gemini GenerateContent API 的协议适配。
 type GeminiClient struct {
 	apiKey     string
 	baseURL    string
 	defaultMod string
 }
 
-// NewGeminiClient 创建一个 Gemini 协议客户端。
 func NewGeminiClient(cfg GeminiConfig) (*GeminiClient, error) {
 	if strings.TrimSpace(cfg.APIKey) == "" {
 		return nil, fmt.Errorf("gemini api key is required")
@@ -40,12 +37,10 @@ func NewGeminiClient(cfg GeminiConfig) (*GeminiClient, error) {
 	}, nil
 }
 
-// Name 返回当前客户端的 provider 类型。
 func (c *GeminiClient) Name() string {
 	return "gemini"
 }
 
-// Complete 发起一次统一请求，并将 Gemini 响应转换为公共 Response。
 func (c *GeminiClient) Complete(ctx context.Context, req Request) (Response, error) {
 	model := strings.TrimSpace(req.Model)
 	if model == "" {

--- a/internal/provider/http.go
+++ b/internal/provider/http.go
@@ -11,12 +11,10 @@ import (
 	"time"
 )
 
-// defaultHTTPClient 返回 provider 统一使用的默认 HTTP 客户端。
 func defaultHTTPClient() *http.Client {
 	return &http.Client{Timeout: 90 * time.Second}
 }
 
-// postJSON 负责发送 JSON POST 请求并解析 JSON 响应。
 func postJSON(ctx context.Context, client *http.Client, url string, headers map[string]string, requestBody any, responseBody any) error {
 	payload, err := json.Marshal(requestBody)
 	if err != nil {

--- a/internal/provider/openai.go
+++ b/internal/provider/openai.go
@@ -7,21 +7,18 @@ import (
 	"strings"
 )
 
-// OpenAIConfig 描述 OpenAI 协议客户端所需的初始化参数。
 type OpenAIConfig struct {
 	APIKey  string
 	BaseURL string
 	Model   string
 }
 
-// OpenAIClient 实现基于 OpenAI Chat Completions 的协议适配。
 type OpenAIClient struct {
 	apiKey     string
 	baseURL    string
 	defaultMod string
 }
 
-// NewOpenAIClient 创建一个 OpenAI 协议客户端。
 func NewOpenAIClient(cfg OpenAIConfig) (*OpenAIClient, error) {
 	if strings.TrimSpace(cfg.APIKey) == "" {
 		return nil, fmt.Errorf("openai api key is required")
@@ -40,12 +37,10 @@ func NewOpenAIClient(cfg OpenAIConfig) (*OpenAIClient, error) {
 	}, nil
 }
 
-// Name 返回当前客户端的 provider 类型。
 func (c *OpenAIClient) Name() string {
 	return "openai"
 }
 
-// Complete 发起一次统一请求，并将 OpenAI 响应转换为公共 Response。
 func (c *OpenAIClient) Complete(ctx context.Context, req Request) (Response, error) {
 	model := strings.TrimSpace(req.Model)
 	if model == "" {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1,4 +1,3 @@
-// Package provider 定义统一模型接口及不同协议适配器共享的数据结构。
 package provider
 
 import (
@@ -6,31 +5,22 @@ import (
 	"encoding/json"
 )
 
-// Role 表示统一消息模型中的角色类型。
 type Role string
 
 const (
-	// RoleSystem 表示系统提示消息。
-	RoleSystem Role = "system"
-	// RoleUser 表示用户输入消息。
-	RoleUser Role = "user"
-	// RoleAssistant 表示模型生成的助手消息。
+	RoleSystem    Role = "system"
+	RoleUser      Role = "user"
 	RoleAssistant Role = "assistant"
-	// RoleTool 表示工具执行结果消息。
-	RoleTool Role = "tool"
+	RoleTool      Role = "tool"
 )
 
-// StopReason 表示一次模型响应结束的原因。
 type StopReason string
 
 const (
-	// StopReasonEndTurn 表示本轮输出自然结束。
 	StopReasonEndTurn StopReason = "end_turn"
-	// StopReasonToolUse 表示模型请求先执行工具再继续推理。
 	StopReasonToolUse StopReason = "tool_use"
 )
 
-// Message 是跨 provider 复用的统一消息结构。
 type Message struct {
 	Role       Role       `json:"role"`
 	Content    string     `json:"content,omitempty"`
@@ -39,21 +29,18 @@ type Message struct {
 	Name       string     `json:"name,omitempty"`
 }
 
-// ToolCall 描述模型发出的单次工具调用请求。
 type ToolCall struct {
 	ID        string          `json:"id"`
 	Name      string          `json:"name"`
 	Arguments json.RawMessage `json:"arguments"`
 }
 
-// ToolDefinition 描述暴露给模型使用的工具定义。
 type ToolDefinition struct {
 	Name        string         `json:"name"`
 	Description string         `json:"description"`
 	InputSchema map[string]any `json:"input_schema"`
 }
 
-// Request 表示发送给 provider 的统一请求。
 type Request struct {
 	Model       string           `json:"model"`
 	Messages    []Message        `json:"messages"`
@@ -62,23 +49,18 @@ type Request struct {
 	Temperature float64          `json:"temperature,omitempty"`
 }
 
-// Response 表示 provider 返回的统一响应。
 type Response struct {
 	Message    Message    `json:"message"`
 	StopReason StopReason `json:"stop_reason"`
 	Usage      Usage      `json:"usage"`
 }
 
-// Usage 记录本次请求的 token 使用情况。
 type Usage struct {
 	InputTokens  int `json:"input_tokens"`
 	OutputTokens int `json:"output_tokens"`
 }
 
-// Client 定义统一的模型调用接口。
 type Client interface {
-	// Name 返回当前客户端对应的 provider 类型标识。
 	Name() string
-	// Complete 发起一次统一请求，并返回归一化后的响应结果。
 	Complete(ctx context.Context, req Request) (Response, error)
 }

--- a/internal/tools/bash.go
+++ b/internal/tools/bash.go
@@ -11,7 +11,6 @@ import (
 	"github.com/minorcell/mini-claude-code/internal/provider"
 )
 
-// BashTool 提供工作区内的 shell 命令执行能力。
 type BashTool struct {
 	root            string
 	defaultTimeout  time.Duration
@@ -24,7 +23,6 @@ type bashArgs struct {
 	TimeoutSeconds int    `json:"timeout_seconds,omitempty"`
 }
 
-// NewBashTool 创建一个 bash 工具实例。
 func NewBashTool(root string) *BashTool {
 	return &BashTool{
 		root:            root,
@@ -33,7 +31,6 @@ func NewBashTool(root string) *BashTool {
 	}
 }
 
-// Definition 返回 bash 工具的模型可见定义。
 func (t *BashTool) Definition() provider.ToolDefinition {
 	return provider.ToolDefinition{
 		Name:        "bash",
@@ -59,7 +56,6 @@ func (t *BashTool) Definition() provider.ToolDefinition {
 	}
 }
 
-// Execute 执行一次 bash 工具调用。
 func (t *BashTool) Execute(ctx context.Context, invocation Invocation) (Result, error) {
 	var args bashArgs
 	if err := json.Unmarshal(invocation.Arguments, &args); err != nil {
@@ -124,7 +120,6 @@ func (t *BashTool) Execute(ctx context.Context, invocation Invocation) (Result, 
 	}, nil
 }
 
-// trimOutput 按给定上限截断命令输出，并返回是否发生截断。
 func trimOutput(data []byte, limit int) (string, bool) {
 	if len(data) <= limit {
 		return string(data), false

--- a/internal/tools/defaults.go
+++ b/internal/tools/defaults.go
@@ -1,6 +1,5 @@
 package tools
 
-// DefaultRegistry 返回带默认拦截器和内置工具的注册中心。
 func DefaultRegistry(workspace string) *Registry {
 	registry := NewRegistry(
 		WorkspaceInterceptor{Root: workspace},

--- a/internal/tools/edit_tool.go
+++ b/internal/tools/edit_tool.go
@@ -10,7 +10,6 @@ import (
 	"github.com/minorcell/mini-claude-code/internal/provider"
 )
 
-// EditTool 提供文件内容精确编辑能力。
 type EditTool struct {
 	root string
 }
@@ -22,14 +21,12 @@ type editArgs struct {
 	All        bool   `json:"all,omitempty"`
 }
 
-// NewEditTool 创建一个文件编辑工具实例。
 func NewEditTool(root string) *EditTool {
 	return &EditTool{
 		root: root,
 	}
 }
 
-// Definition 返回文件编辑工具的模型可见定义。
 func (t *EditTool) Definition() provider.ToolDefinition {
 	return provider.ToolDefinition{
 		Name:        "edit",
@@ -59,7 +56,6 @@ func (t *EditTool) Definition() provider.ToolDefinition {
 	}
 }
 
-// Execute 执行文件编辑操作。
 func (t *EditTool) Execute(_ context.Context, invocation Invocation) (Result, error) {
 	var args editArgs
 	if err := json.Unmarshal(invocation.Arguments, &args); err != nil {

--- a/internal/tools/glob_tool.go
+++ b/internal/tools/glob_tool.go
@@ -12,7 +12,6 @@ import (
 	"github.com/minorcell/mini-claude-code/internal/provider"
 )
 
-// GlobTool 按文件名模式匹配查找文件。
 type GlobTool struct {
 	root string
 }
@@ -23,14 +22,12 @@ type globArgs struct {
 	MaxResults int    `json:"max_results,omitempty"`
 }
 
-// NewGlobTool 创建一个 glob 搜索工具实例。
 func NewGlobTool(root string) *GlobTool {
 	return &GlobTool{
 		root: root,
 	}
 }
 
-// Definition 返回 glob 工具的模型可见定义。
 func (t *GlobTool) Definition() provider.ToolDefinition {
 	return provider.ToolDefinition{
 		Name:        "glob",
@@ -56,7 +53,6 @@ func (t *GlobTool) Definition() provider.ToolDefinition {
 	}
 }
 
-// Execute 执行 glob 搜索。
 func (t *GlobTool) Execute(_ context.Context, invocation Invocation) (Result, error) {
 	var args globArgs
 	if err := json.Unmarshal(invocation.Arguments, &args); err != nil {

--- a/internal/tools/grep_tool.go
+++ b/internal/tools/grep_tool.go
@@ -13,7 +13,6 @@ import (
 	"github.com/minorcell/mini-claude-code/internal/provider"
 )
 
-// GrepTool 在文件内容中搜索匹配的文本。
 type GrepTool struct {
 	root string
 }
@@ -28,14 +27,12 @@ type grepArgs struct {
 	Context    int    `json:"context,omitempty"`
 }
 
-// NewGrepTool 创建一个 grep 搜索工具实例。
 func NewGrepTool(root string) *GrepTool {
 	return &GrepTool{
 		root: root,
 	}
 }
 
-// Definition 返回 grep 工具的模型可见定义。
 func (t *GrepTool) Definition() provider.ToolDefinition {
 	return provider.ToolDefinition{
 		Name:        "grep",
@@ -77,7 +74,6 @@ func (t *GrepTool) Definition() provider.ToolDefinition {
 	}
 }
 
-// Execute 执行 grep 搜索。
 func (t *GrepTool) Execute(_ context.Context, invocation Invocation) (Result, error) {
 	var args grepArgs
 	if err := json.Unmarshal(invocation.Arguments, &args); err != nil {

--- a/internal/tools/interceptors.go
+++ b/internal/tools/interceptors.go
@@ -7,12 +7,10 @@ import (
 	"strings"
 )
 
-// WorkspaceInterceptor 用于阻止文件与命令路径逃逸出工作区。
 type WorkspaceInterceptor struct {
 	Root string
 }
 
-// Before 在执行前检查路径参数是否仍位于工作区内。
 func (i WorkspaceInterceptor) Before(_ context.Context, invocation *Invocation) error {
 	switch invocation.ToolName {
 	case "filesystem":
@@ -29,13 +27,10 @@ func (i WorkspaceInterceptor) Before(_ context.Context, invocation *Invocation) 
 	return nil
 }
 
-// After 是工作区拦截器的后置钩子，当前不做额外处理。
 func (WorkspaceInterceptor) After(_ context.Context, _ Invocation, _ *Result, _ error) {}
 
-// ShellSafetyInterceptor 用于拦截明显危险的 shell 指令片段。
 type ShellSafetyInterceptor struct{}
 
-// Before 在执行 bash 前检查是否命中危险命令片段。
 func (ShellSafetyInterceptor) Before(_ context.Context, invocation *Invocation) error {
 	if invocation.ToolName != "bash" {
 		return nil
@@ -60,10 +55,8 @@ func (ShellSafetyInterceptor) Before(_ context.Context, invocation *Invocation) 
 	return nil
 }
 
-// After 是 shell 安全拦截器的后置钩子，当前不做额外处理。
 func (ShellSafetyInterceptor) After(_ context.Context, _ Invocation, _ *Result, _ error) {}
 
-// SafeJoin 将候选路径限制在给定工作区内，并返回安全的绝对路径。
 func SafeJoin(root string, candidate string) (string, error) {
 	rootAbs, err := filepath.Abs(root)
 	if err != nil {
@@ -89,7 +82,6 @@ func SafeJoin(root string, candidate string) (string, error) {
 	return target, nil
 }
 
-// stringArg 从已解析参数中安全读取字符串值。
 func stringArg(arguments map[string]any, key string) (string, bool) {
 	if arguments == nil {
 		return "", false

--- a/internal/tools/interceptors_test.go
+++ b/internal/tools/interceptors_test.go
@@ -2,7 +2,6 @@ package tools
 
 import "testing"
 
-// TestSafeJoinRejectsEscape 验证 SafeJoin 会阻止路径逃逸出工作区。
 func TestSafeJoinRejectsEscape(t *testing.T) {
 	root := t.TempDir()
 

--- a/internal/tools/list_tool.go
+++ b/internal/tools/list_tool.go
@@ -12,7 +12,6 @@ import (
 	"github.com/minorcell/mini-claude-code/internal/provider"
 )
 
-// ListTool 提供目录列表和文件信息查询能力。
 type ListTool struct {
 	root string
 }
@@ -23,14 +22,12 @@ type listArgs struct {
 	All     bool   `json:"all,omitempty"`
 }
 
-// NewListTool 创建一个目录列表工具实例。
 func NewListTool(root string) *ListTool {
 	return &ListTool{
 		root: root,
 	}
 }
 
-// Definition 返回目录列表工具的模型可见定义。
 func (t *ListTool) Definition() provider.ToolDefinition {
 	return provider.ToolDefinition{
 		Name:        "list",
@@ -56,7 +53,6 @@ func (t *ListTool) Definition() provider.ToolDefinition {
 	}
 }
 
-// Execute 执行目录列表操作。
 func (t *ListTool) Execute(_ context.Context, invocation Invocation) (Result, error) {
 	var args listArgs
 	if err := json.Unmarshal(invocation.Arguments, &args); err != nil {

--- a/internal/tools/read_tool.go
+++ b/internal/tools/read_tool.go
@@ -11,7 +11,6 @@ import (
 	"github.com/minorcell/mini-claude-code/internal/provider"
 )
 
-// ReadTool 提供文件读取能力，支持按行号范围读取。
 type ReadTool struct {
 	root         string
 	maxReadBytes int
@@ -24,7 +23,6 @@ type readArgs struct {
 	MaxBytes int    `json:"max_bytes,omitempty"`
 }
 
-// NewReadTool 创建一个文件读取工具实例。
 func NewReadTool(root string) *ReadTool {
 	return &ReadTool{
 		root:         root,
@@ -32,7 +30,6 @@ func NewReadTool(root string) *ReadTool {
 	}
 }
 
-// Definition 返回文件读取工具的模型可见定义。
 func (t *ReadTool) Definition() provider.ToolDefinition {
 	return provider.ToolDefinition{
 		Name:        "read",
@@ -62,7 +59,6 @@ func (t *ReadTool) Definition() provider.ToolDefinition {
 	}
 }
 
-// Execute 执行文件读取操作。
 func (t *ReadTool) Execute(_ context.Context, invocation Invocation) (Result, error) {
 	var args readArgs
 	if err := json.Unmarshal(invocation.Arguments, &args); err != nil {

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -9,13 +9,11 @@ import (
 	"github.com/minorcell/mini-claude-code/internal/provider"
 )
 
-// Registry 管理工具注册、工具定义导出与统一执行流程。
 type Registry struct {
 	tools        map[string]Tool
 	interceptors []Interceptor
 }
 
-// NewRegistry 创建一个新的工具注册中心。
 func NewRegistry(interceptors ...Interceptor) *Registry {
 	return &Registry{
 		tools:        make(map[string]Tool),
@@ -23,7 +21,6 @@ func NewRegistry(interceptors ...Interceptor) *Registry {
 	}
 }
 
-// Register 注册一个工具；同名工具会被拒绝。
 func (r *Registry) Register(tool Tool) error {
 	definition := tool.Definition()
 	if definition.Name == "" {
@@ -36,14 +33,12 @@ func (r *Registry) Register(tool Tool) error {
 	return nil
 }
 
-// MustRegister 注册工具，失败时直接 panic，适合程序启动阶段使用。
 func (r *Registry) MustRegister(tool Tool) {
 	if err := r.Register(tool); err != nil {
 		panic(err)
 	}
 }
 
-// Definitions 返回当前所有已注册工具的定义列表。
 func (r *Registry) Definitions() []provider.ToolDefinition {
 	names := make([]string, 0, len(r.tools))
 	for name := range r.tools {
@@ -58,7 +53,6 @@ func (r *Registry) Definitions() []provider.ToolDefinition {
 	return definitions
 }
 
-// Execute 按统一流程执行一次工具调用，并串联所有拦截器。
 func (r *Registry) Execute(ctx context.Context, call provider.ToolCall, state State) (Result, error) {
 	tool, ok := r.tools[call.Name]
 	if !ok {

--- a/internal/tools/todo_tool.go
+++ b/internal/tools/todo_tool.go
@@ -10,7 +10,6 @@ import (
 	"github.com/minorcell/mini-claude-code/internal/provider"
 )
 
-// TodoTool 维护当前任务的待办列表，适合复杂任务的分步推进。
 type TodoTool struct {
 	mu    sync.Mutex
 	lists map[string][]todoItem
@@ -26,14 +25,12 @@ type todoItem struct {
 	Status  string `json:"status"`
 }
 
-// NewTodoTool 创建一个 todo 工具实例。
 func NewTodoTool() *TodoTool {
 	return &TodoTool{
 		lists: make(map[string][]todoItem),
 	}
 }
 
-// Definition 返回 todo 工具的模型可见定义。
 func (t *TodoTool) Definition() provider.ToolDefinition {
 	return provider.ToolDefinition{
 		Name:        "todo",
@@ -70,7 +67,6 @@ func (t *TodoTool) Definition() provider.ToolDefinition {
 	}
 }
 
-// Execute 执行一次 todo 工具调用。
 func (t *TodoTool) Execute(_ context.Context, invocation Invocation) (Result, error) {
 	var args todoArgs
 	if err := json.Unmarshal(invocation.Arguments, &args); err != nil {

--- a/internal/tools/types.go
+++ b/internal/tools/types.go
@@ -1,4 +1,3 @@
-// Package tools 提供统一工具注册、拦截与内置工具实现。
 package tools
 
 import (
@@ -9,13 +8,11 @@ import (
 	"github.com/minorcell/mini-claude-code/internal/provider"
 )
 
-// State 描述一次工具执行时的上下文状态。
 type State struct {
 	WorkingDir string
 	SessionID  string
 }
 
-// Invocation 表示一次已经解析好的工具调用请求。
 type Invocation struct {
 	ToolName   string
 	CallID     string
@@ -25,7 +22,6 @@ type Invocation struct {
 	ParsedArgs map[string]any
 }
 
-// Result 表示工具执行完成后的统一结果。
 type Result struct {
 	ToolName string         `json:"tool_name"`
 	OK       bool           `json:"ok"`
@@ -33,7 +29,6 @@ type Result struct {
 	Metadata map[string]any `json:"metadata,omitempty"`
 }
 
-// Render 将工具结果渲染为适合回写给模型的 JSON 文本。
 func (r Result) Render() string {
 	data, err := json.MarshalIndent(r, "", "  ")
 	if err != nil {
@@ -42,18 +37,12 @@ func (r Result) Render() string {
 	return string(data)
 }
 
-// Tool 定义内置工具需要实现的统一接口。
 type Tool interface {
-	// Definition 返回暴露给模型的工具描述。
 	Definition() provider.ToolDefinition
-	// Execute 执行一次工具调用。
 	Execute(ctx context.Context, invocation Invocation) (Result, error)
 }
 
-// Interceptor 定义工具执行前后的拦截扩展点。
 type Interceptor interface {
-	// Before 在工具执行前触发，可用于校验、审计或阻断调用。
 	Before(ctx context.Context, invocation *Invocation) error
-	// After 在工具执行后触发，可用于记录结果或补充副作用。
 	After(ctx context.Context, invocation Invocation, result *Result, err error)
 }

--- a/internal/tools/webfetch.go
+++ b/internal/tools/webfetch.go
@@ -19,7 +19,6 @@ var (
 	spaceStripper = regexp.MustCompile(`\s+`)
 )
 
-// WebFetchTool 提供基于 HTTP(S) 的网页与接口抓取能力。
 type WebFetchTool struct {
 	client       *http.Client
 	maxBodyBytes int
@@ -29,7 +28,6 @@ type webFetchArgs struct {
 	URL string `json:"url"`
 }
 
-// NewWebFetchTool 创建一个网页抓取工具实例。
 func NewWebFetchTool() *WebFetchTool {
 	return &WebFetchTool{
 		client: &http.Client{
@@ -39,7 +37,6 @@ func NewWebFetchTool() *WebFetchTool {
 	}
 }
 
-// Definition 返回 webfetch 工具的模型可见定义。
 func (t *WebFetchTool) Definition() provider.ToolDefinition {
 	return provider.ToolDefinition{
 		Name:        "webfetch",
@@ -57,7 +54,6 @@ func (t *WebFetchTool) Definition() provider.ToolDefinition {
 	}
 }
 
-// Execute 执行一次网页抓取工具调用。
 func (t *WebFetchTool) Execute(ctx context.Context, invocation Invocation) (Result, error) {
 	var args webFetchArgs
 	if err := json.Unmarshal(invocation.Arguments, &args); err != nil {
@@ -116,7 +112,6 @@ func (t *WebFetchTool) Execute(ctx context.Context, invocation Invocation) (Resu
 	}, nil
 }
 
-// normalizeFetchedContent 对抓取结果做最小清洗，便于模型进一步消费。
 func normalizeFetchedContent(body string, contentType string) string {
 	if strings.Contains(strings.ToLower(contentType), "text/html") {
 		body = htmlStripper.ReplaceAllString(body, " ")

--- a/internal/tools/write_tool.go
+++ b/internal/tools/write_tool.go
@@ -11,7 +11,6 @@ import (
 	"github.com/minorcell/mini-claude-code/internal/provider"
 )
 
-// WriteTool 提供文件写入能力，支持创建新文件和覆盖/追加内容。
 type WriteTool struct {
 	root string
 }
@@ -23,14 +22,12 @@ type writeArgs struct {
 	Create  bool   `json:"create,omitempty"`
 }
 
-// NewWriteTool 创建一个文件写入工具实例。
 func NewWriteTool(root string) *WriteTool {
 	return &WriteTool{
 		root: root,
 	}
 }
 
-// Definition 返回文件写入工具的模型可见定义。
 func (t *WriteTool) Definition() provider.ToolDefinition {
 	return provider.ToolDefinition{
 		Name:        "write",
@@ -60,7 +57,6 @@ func (t *WriteTool) Definition() provider.ToolDefinition {
 	}
 }
 
-// Execute 执行文件写入操作。
 func (t *WriteTool) Execute(_ context.Context, invocation Invocation) (Result, error) {
 	var args writeArgs
 	if err := json.Unmarshal(invocation.Arguments, &args); err != nil {

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1,4 +1,3 @@
-// Package tui 提供基于 Bubble Tea 的终端交互界面。
 package tui
 
 import (
@@ -9,7 +8,6 @@ import (
 	"github.com/minorcell/mini-claude-code/internal/core"
 )
 
-// App 聚合启动 TUI 所需的运行时依赖和展示信息。
 type App struct {
 	Agent        *core.Agent
 	Session      *core.Session
@@ -21,7 +19,6 @@ type App struct {
 	Workspace    string
 }
 
-// Run 启动 TUI 主循环。
 func Run(app App) error {
 	program := tea.NewProgram(
 		newModel(app),

--- a/internal/tui/components.go
+++ b/internal/tui/components.go
@@ -1,5 +1,1 @@
 package tui
-
-// This file is kept for backward compatibility.
-// All component rendering functions have been moved to the components/ subdirectory.
-// The functions are automatically available due to Go's package structure.

--- a/internal/tui/composer.go
+++ b/internal/tui/composer.go
@@ -6,7 +6,6 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
-// renderComposer renders the composer panel with input and file candidates
 func (m model) renderComposer() string {
 	hint := "Enter sends | Ctrl+J newline"
 	if m.busy && m.queuedPrompt != "" {
@@ -43,7 +42,6 @@ func (m model) renderComposer() string {
 	)
 }
 
-// renderQueuedPrompt renders the queued prompt preview
 func (m model) renderQueuedPrompt(width int) string {
 	preview := strings.TrimSpace(m.queuedPrompt)
 	if preview == "" {
@@ -60,7 +58,6 @@ func (m model) renderQueuedPrompt(width int) string {
 		Render(lipgloss.JoinVertical(lipgloss.Left, lines...))
 }
 
-// footerHint returns the appropriate footer hint based on current state
 func (m model) footerHint() string {
 	switch {
 	case m.busy && m.queuedPrompt != "":

--- a/internal/tui/file_picker.go
+++ b/internal/tui/file_picker.go
@@ -4,7 +4,6 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
-// renderFileCandidateList renders the file candidate list for the file picker
 func (m model) renderFileCandidateList(width int) string {
 	if m.filePicker.Loading {
 		return m.theme.dim.Render("Indexing workspace files...")

--- a/internal/tui/main.go
+++ b/internal/tui/main.go
@@ -6,7 +6,6 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
-// renderMain renders the main layout with conversation and trace panels
 func (m model) renderMain() string {
 	columnGap := m.theme.canvasFill().Render(" ")
 	rowGap := m.theme.canvasFill().Width(m.layout.totalWidth).Render("")
@@ -36,7 +35,6 @@ func (m model) renderMain() string {
 	return lipgloss.JoinHorizontal(lipgloss.Top, conversation, columnGap, trace)
 }
 
-// renderFooter renders the footer with help text and error messages
 func (m model) renderFooter() string {
 	space := m.theme.canvasFill().Render(" ")
 	helpLine := lipgloss.JoinHorizontal(
@@ -56,7 +54,6 @@ func (m model) renderFooter() string {
 		Render(body)
 }
 
-// renderPanel renders a generic panel with title, hint, and body
 func (m model) renderPanel(title string, hint string, body string, width int, height int, focused bool, accent string) string {
 	innerWidth := max(1, width-m.theme.panelBase.GetHorizontalFrameSize())
 	innerHeight := max(0, height-m.panelBorderHeight())
@@ -80,12 +77,10 @@ func (m model) renderPanel(title string, hint string, body string, width int, he
 		Render(content)
 }
 
-// panelBorderWidth returns the horizontal border width of panels
 func (m model) panelBorderWidth() int {
 	return m.theme.panelBase.GetHorizontalBorderSize() + m.theme.panelBase.GetHorizontalMargins()
 }
 
-// panelBorderHeight returns the vertical border height of panels
 func (m model) panelBorderHeight() int {
 	return m.theme.panelBase.GetVerticalBorderSize() + m.theme.panelBase.GetVerticalMargins()
 }

--- a/internal/tui/sidebar.go
+++ b/internal/tui/sidebar.go
@@ -7,13 +7,11 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
-// metricRow represents a row in the sidebar metrics display
 type metricRow struct {
 	Label string
 	Value string
 }
 
-// renderOverviewBody renders the overview panel with usage statistics and status
 func (m model) renderOverviewBody(width int) string {
 	turnUsageTotal := m.currentTurnUsage.InputTokens + m.currentTurnUsage.OutputTokens
 	sessionUsageTotal := m.sessionUsage.InputTokens + m.sessionUsage.OutputTokens
@@ -49,7 +47,6 @@ func (m model) renderOverviewBody(width int) string {
 	return lipgloss.JoinVertical(lipgloss.Left, blocks...)
 }
 
-// renderSidebarRows renders multiple metric rows in the sidebar
 func (m model) renderSidebarRows(width int, rows []metricRow) string {
 	lines := make([]string, 0, len(rows))
 	for _, row := range rows {
@@ -64,7 +61,6 @@ func (m model) renderSidebarRows(width int, rows []metricRow) string {
 	return lipgloss.JoinVertical(lipgloss.Left, lines...)
 }
 
-// renderTodoSection renders the todo items section
 func (m model) renderTodoSection(width int) string {
 	lines := []string{
 		m.theme.badge("TODO", m.theme.teal, m.theme.ink),
@@ -81,7 +77,6 @@ func (m model) renderTodoSection(width int) string {
 	return lipgloss.JoinVertical(lipgloss.Left, lines...)
 }
 
-// todoStatusIcon returns the appropriate icon for todo status
 func todoStatusIcon(status string) string {
 	switch status {
 	case "completed":

--- a/internal/tui/transcript.go
+++ b/internal/tui/transcript.go
@@ -4,7 +4,6 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
-// renderTranscriptEntry renders a single transcript entry with role-based styling
 func (m model) renderTranscriptEntry(entry transcriptEntry, width int) string {
 	accent := m.theme.muted
 	switch entry.Role {

--- a/internal/tui/utils.go
+++ b/internal/tui/utils.go
@@ -13,7 +13,6 @@ type renderedToolResult struct {
 	Metadata map[string]any `json:"metadata"`
 }
 
-// summarizeToolCall creates a summary of a tool call for display
 func summarizeToolCall(name string, rawInput string) (string, string) {
 	args := parseJSONMap(rawInput)
 	switch name {
@@ -47,7 +46,6 @@ func summarizeToolCall(name string, rawInput string) (string, string) {
 	}
 }
 
-// summarizeToolResult creates a summary of a tool result for display
 func summarizeToolResult(name string, rawInput string, rawOutput string, isError bool) (string, string) {
 	args := parseJSONMap(rawInput)
 	result := parseRenderedToolResult(rawOutput)
@@ -110,7 +108,6 @@ func summarizeToolResult(name string, rawInput string, rawOutput string, isError
 	}
 }
 
-// parseJSONMap parses a JSON string into a map
 func parseJSONMap(raw string) map[string]any {
 	out := map[string]any{}
 	trimmed := strings.TrimSpace(raw)
@@ -121,14 +118,12 @@ func parseJSONMap(raw string) map[string]any {
 	return out
 }
 
-// parseRenderedToolResult parses a rendered tool result from JSON
 func parseRenderedToolResult(raw string) renderedToolResult {
 	result := renderedToolResult{}
 	_ = json.Unmarshal([]byte(strings.TrimSpace(raw)), &result)
 	return result
 }
 
-// previewText creates a preview of text with a limit
 func previewText(value string, limit int) string {
 	normalized := strings.Join(strings.Fields(strings.TrimSpace(value)), " ")
 	if normalized == "" {
@@ -140,7 +135,6 @@ func previewText(value string, limit int) string {
 	return normalized[:limit-3] + "..."
 }
 
-// truncateMiddle truncates text from the middle
 func truncateMiddle(value string, limit int) string {
 	if limit <= 0 || len(value) <= limit {
 		return value
@@ -153,7 +147,6 @@ func truncateMiddle(value string, limit int) string {
 	return value[:head] + "..." + value[len(value)-tail:]
 }
 
-// firstLine returns the first line of text
 func firstLine(value string) string {
 	value = strings.TrimSpace(value)
 	if value == "" {
@@ -165,7 +158,6 @@ func firstLine(value string) string {
 	return value
 }
 
-// lineCount returns the number of lines in text
 func lineCount(value string) int {
 	trimmed := strings.TrimSpace(value)
 	if trimmed == "" {
@@ -174,7 +166,6 @@ func lineCount(value string) int {
 	return strings.Count(trimmed, "\n") + 1
 }
 
-// stringValue converts any value to string
 func stringValue(value any) string {
 	if value == nil {
 		return ""
@@ -187,7 +178,6 @@ func stringValue(value any) string {
 	}
 }
 
-// intValue converts any value to int
 func intValue(value any) int {
 	switch actual := value.(type) {
 	case int:
@@ -203,7 +193,6 @@ func intValue(value any) int {
 	}
 }
 
-// summarizeTodoArgs summarizes todo arguments
 func summarizeTodoArgs(args map[string]any) (count int, inProgress int, completed int) {
 	rawItems, ok := args["items"].([]any)
 	if !ok {
@@ -225,7 +214,6 @@ func summarizeTodoArgs(args map[string]any) (count int, inProgress int, complete
 	return count, inProgress, completed
 }
 
-// timeSince returns the duration since a given time
 func timeSince(start time.Time) time.Duration {
 	if start.IsZero() {
 		return 0
@@ -233,7 +221,6 @@ func timeSince(start time.Time) time.Duration {
 	return time.Since(start)
 }
 
-// formatCount formats a count with appropriate units
 func formatCount(value int) string {
 	if value <= 0 {
 		return "-"


### PR DESCRIPTION
Requested by @minorcell

本 PR 移除了项目中所有 Go 源文件的代码注释，对应 issue #35。

## 变更内容
- 移除了 33 个文件中的所有单行注释（`// ...`）
- 移除了所有多行块注释（`/* ... */`）
- 保留了编译器指令（如 `//go:embed`）
- 保留了字符串字面量中的内容不变

## 验证
- 代码编译通过（`go build ./...`）
- 所有测试通过