### PR TITLE
refactor: 移除冗余的防御性编程代码

### DIFF
--- a/internal/core/agent.go
+++ b/internal/core/agent.go
@@ -235,10 +235,10 @@ func stringifyArguments(arguments json.RawMessage) string {
 	}
 
 	var out bytes.Buffer
-	if err := json.Indent(&out, arguments, "", "  "); err == nil {
-		return out.String()
+	if err := json.Indent(&out, arguments, "", "  "); err != nil {
+		return string(arguments)
 	}
-	return string(arguments)
+	return out.String()
 }
 
 func emitProgress(observer TurnObserver, event ProgressEvent) {

--- a/internal/tools/interceptors.go
+++ b/internal/tools/interceptors.go
@@ -91,9 +91,6 @@ func SafeJoin(root string, candidate string) (string, error) {
 
 // stringArg 从已解析参数中安全读取字符串值。
 func stringArg(arguments map[string]any, key string) (string, bool) {
-	if arguments == nil {
-		return "", false
-	}
 	value, ok := arguments[key]
 	if !ok {
 		return "", false

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -77,9 +77,7 @@ func (r *Registry) Execute(ctx context.Context, call provider.ToolCall, state St
 		SessionID:  state.SessionID,
 		Arguments:  call.Arguments,
 	}
-	if len(call.Arguments) > 0 {
-		_ = json.Unmarshal(call.Arguments, &invocation.ParsedArgs)
-	}
+	_ = json.Unmarshal(call.Arguments, &invocation.ParsedArgs)
 
 	for _, interceptor := range r.interceptors {
 		if err := interceptor.Before(ctx, &invocation); err != nil {

--- a/internal/tools/write_tool.go
+++ b/internal/tools/write_tool.go
@@ -77,10 +77,8 @@ func (t *WriteTool) Execute(_ context.Context, invocation Invocation) (Result, e
 	}
 
 	create := true
-	if invocation.ParsedArgs != nil {
-		if v, ok := invocation.ParsedArgs["create"].(bool); ok {
-			create = v
-		}
+	if v, ok := invocation.ParsedArgs["create"].(bool); ok {
+		create = v
 	}
 
 	return t.write(target, args.Content, args.Append, create)


### PR DESCRIPTION
- write_tool.go: 移除 map 访问前不必要的 nil 检查（Go 中访问 nil map 是安全的）
- interceptors.go: 同上，移除 stringArg 中的 nil 检查
- registry.go: 移除 json.Unmarshal 前多余的长度检查（error 已被忽略）
- agent.go: 将倒置的错误检查改为标准 Go 错误处理惯用法

Generated with [codeagent](https://github.com/qbox/codeagent)